### PR TITLE
compat: boxed is now swi-boxed so that websites can use .boxed

### DIFF
--- a/Steam Web Integration.user.js
+++ b/Steam Web Integration.user.js
@@ -75,7 +75,7 @@ function onChange(elem) {
 
 function createBoxNode() {
     return $(`<div/>`, {
-        "class": `swi-block${settings.boxed ? ` boxed` : ``}`
+        "class": `swi-block${settings.boxed ? ` swi-boxed` : ``}`
     });
 }
 
@@ -602,7 +602,7 @@ function init() {
                 display: inline-block;
                 line-height: initial;
             }
-            .swi-block.boxed {
+            .swi-block.swi-boxed {
                 background: rgba(0, 0, 0, 0.7);
                 border-radius: 5px;
                 margin: auto 4px auto 4px;

--- a/Steam Web Integration.user.js
+++ b/Steam Web Integration.user.js
@@ -29,7 +29,7 @@
 // @run-at       document-start
 // @supportURL   https://github.com/Revadike/SteamWebIntegration/issues/
 // @updateURL    https://github.com/Revadike/SteamWebIntegration/raw/master/Steam%20Web%20Integration.user.js
-// @version      1.11.0
+// @version      1.11.1
 // ==/UserScript==
 
 // ==Code==


### PR DESCRIPTION
![](https://cdn.discordapp.com/attachments/440861143309877259/821855981705101353/unknown.png)
Cute box, one would think.
Except SWI wants to use the 'boxed' class. Other websites might want to name a class that too.

Arguably a hotfix for Barter.vg use 😆 