### PR TITLE
Steamtracker fixes; version increment

### DIFF
--- a/Steam Web Integration.user.js
+++ b/Steam Web Integration.user.js
@@ -31,7 +31,7 @@
 // @run-at       document-start
 // @supportURL   https://github.com/Revadike/SteamWebIntegration/issues/
 // @updateURL    https://github.com/Revadike/SteamWebIntegration/raw/master/Steam%20Web%20Integration.user.js
-// @version      1.11.4
+// @version      1.11.5
 // ==/UserScript==
 
 // ==Code==


### PR DESCRIPTION
ST returns `appid` as int, which was breaking functionality because we were `===`-comparing to a `.toString()`.
I noticed we do a `.find` on an array here, which is potentially quite slow, so instead I changed it to one-time convert array to object for O(1) lookups and (hopefully 😆) added code to remove old storage if needed.


The dynamicstore-sourced lookups are done using `.includes`. I assume making a set or object out of all those arrays would make for faster lookups, but might be computationally expensive itself as many people poll a fresh _dynamicstore_ on every single web request.